### PR TITLE
Added type check for text area 

### DIFF
--- a/src/components/editors/EditableColumnEditor/EditableColumnEditorsRegistry.test.tsx
+++ b/src/components/editors/EditableColumnEditor/EditableColumnEditorsRegistry.test.tsx
@@ -482,6 +482,22 @@ describe('editableColumnEditorsRegistry', () => {
       expect(onChange).toHaveBeenCalledWith('line updated');
     });
 
+    it('Should render control with a non-string type ', () => {
+      render(
+        getControlComponent({
+          value: null,
+          config: createColumnEditConfig({ editor: { type: ColumnEditorType.TEXTAREA } }).editor,
+        })
+      );
+
+      expect(controlSelectors.fieldTextarea()).toBeInTheDocument();
+      expect(controlSelectors.fieldTextarea()).toHaveValue('null');
+
+      fireEvent.change(controlSelectors.fieldTextarea(), { target: { value: 'line updated' } });
+
+      expect(onChange).toHaveBeenCalledWith('line updated');
+    });
+
     it('Should render control with replaced lines and replace line onChange correctly', () => {
       render(
         getControlComponent({

--- a/src/components/editors/EditableColumnEditor/EditableColumnEditorsRegistry.tsx
+++ b/src/components/editors/EditableColumnEditor/EditableColumnEditorsRegistry.tsx
@@ -39,7 +39,7 @@ export const editableColumnEditorsRegistry = createEditableColumnEditorsRegistry
     editor: () => null,
     control: ({ value, onChange, isSaving }) => (
       <TextArea
-        value={(value as string).replaceAll('\\n', '\n')}
+        value={typeof value === 'string' ? (value as string).replaceAll('\\n', '\n') : String(value)}
         onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
           onChange(event.target.value.replaceAll('\n', '\\n'));
         }}


### PR DESCRIPTION
Resolves: #170 

I'm not sure that we should do a type check if a field has a different type not compatible with the editor